### PR TITLE
fix mfa codes

### DIFF
--- a/core/proxy.proto
+++ b/core/proxy.proto
@@ -140,7 +140,7 @@ message ClientMfaStartResponse {
 
 message ClientMfaFinishRequest {
   string token = 1;
-  uint32 code = 2;
+  string code = 2;
 }
 
 message ClientMfaFinishResponse {


### PR DESCRIPTION
Current client mfa codes were of type uint32, which lead to issues as codes may begin with 0.