### PR TITLE
update enrollment settings

### DIFF
--- a/core/proxy.proto
+++ b/core/proxy.proto
@@ -25,9 +25,10 @@ message InitialUserInfo {
   bool enrolled = 8;
 }
 
-message Settings {
+message EnrollmentSettings {
   bool vpn_setup_optional = 1;
   bool only_client_activation = 2;
+  bool admin_device_management = 3;
 }
 
 message EnrollmentStartResponse {
@@ -36,7 +37,7 @@ message EnrollmentStartResponse {
   int64 deadline_timestamp = 3;
   string final_page_content = 5;
   InstanceInfo instance = 7;
-  Settings settings = 8;
+  EnrollmentSettings settings = 8;
 }
 
 message ActivateUserRequest {

--- a/core/proxy.proto
+++ b/core/proxy.proto
@@ -23,6 +23,7 @@ message InitialUserInfo {
   bool is_active = 6;
   repeated string device_names = 7;
   bool enrolled = 8;
+  bool is_admin = 9;
 }
 
 message EnrollmentSettings {


### PR DESCRIPTION
Rename message from Settings to EnrollmentSettings to be more explicit.

Pass admin device management flag in enrollment settings sent in enrollment start response

Related to https://github.com/DefGuard/proxy/issues/111