### PR TITLE
Remove superfluous CreateInterfaceRequest.allowed_ips

### DIFF
--- a/client/client.proto
+++ b/client/client.proto
@@ -25,7 +25,6 @@ message Peer {
 
 message CreateInterfaceRequest {
   InterfaceConfig config = 1;
-  repeated string allowed_ips = 2;
   optional string dns = 3;
 }
 


### PR DESCRIPTION
Use CreateInterfaceRequest.config > peers > Peer.allowed_ips instead.