### PR TITLE
send cookie keys via protos

### DIFF
--- a/core/proxy.proto
+++ b/core/proxy.proto
@@ -272,6 +272,10 @@ message CodeMfaSetupFinishResponse {
   repeated string recovery_codes = 1;
 }
 
+message InitialInfo {
+  bytes private_cookies_key = 1;
+}
+
 /*
  * Error response variant.
  * Due to reverse proxy -> core communication this is how we
@@ -302,6 +306,7 @@ message CoreResponse {
     ClientMfaTokenValidationResponse client_mfa_token_validation = 15;
     CodeMfaSetupStartResponse code_mfa_setup_start_response = 16;
     CodeMfaSetupFinishResponse code_mfa_setup_finish_response = 17;
+    InitialInfo initial_info = 18;
   }
 }
 


### PR DESCRIPTION
Adds core_response::InitialInfo message, used to send private cookies key immediately after core connects to proxy.