### PR TITLE
send core certs during component setup

### DIFF
--- a/v2/common.proto
+++ b/v2/common.proto
@@ -38,7 +38,7 @@ message LogEntry {
  *                        every subsequent gRPC connection.
  */
 message CertBundle {
-  bytes component_cert_der   = 1;
-  bytes ca_cert_der          = 2;
+  bytes component_cert_der = 1;
+  bytes ca_cert_der = 2;
   bytes core_client_cert_der = 3;
 }

--- a/v2/common.proto
+++ b/v2/common.proto
@@ -25,3 +25,20 @@ message LogEntry {
   string timestamp = 4;
   map<string, string> fields = 5;
 }
+
+/*
+ * TLS certificate bundle sent from Core to a component during setup.
+ * All fields are DER-encoded binary.
+ *
+ * component_cert_der   - the component's signed server certificate.
+ * ca_cert_der          - the CA certificate; used by the component to verify
+ *                        Core's client certificate chain during mTLS.
+ * core_client_cert_der - Core's client certificate; stored by the component
+ *                        and used to pin the exact cert Core must present on
+ *                        every subsequent gRPC connection.
+ */
+message CertBundle {
+  bytes component_cert_der   = 1;
+  bytes ca_cert_der          = 2;
+  bytes core_client_cert_der = 3;
+}

--- a/v2/gateway.proto
+++ b/v2/gateway.proto
@@ -98,5 +98,5 @@ service Gateway {
 service GatewaySetup {
   rpc Start(google.protobuf.Empty) returns (stream defguard.common.v2.LogEntry);
   rpc GetCsr(defguard.common.v2.CertificateInfo) returns (defguard.common.v2.DerPayload);
-  rpc SendCert(defguard.common.v2.DerPayload) returns (google.protobuf.Empty);
+  rpc SendCert(defguard.common.v2.CertBundle) returns (google.protobuf.Empty);
 }

--- a/v2/proxy.proto
+++ b/v2/proxy.proto
@@ -226,5 +226,5 @@ service Proxy {
 service ProxySetup {
   rpc Start(google.protobuf.Empty) returns (stream defguard.common.v2.LogEntry);
   rpc GetCsr(defguard.common.v2.CertificateInfo) returns (defguard.common.v2.DerPayload);
-  rpc SendCert(defguard.common.v2.DerPayload) returns (google.protobuf.Empty);
+  rpc SendCert(defguard.common.v2.CertBundle) returns (google.protobuf.Empty);
 }


### PR DESCRIPTION
Update protos for core client cert exchange during component setup.

Required for https://github.com/DefGuard/defguard/issues/2695