### PR TITLE
add device posture types & RPCs

### DIFF
--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -120,6 +120,9 @@ message DeviceConfig {
   int32 keepalive_interval = 10;
   optional LocationMfaMode location_mfa_mode = 11;
   optional ServiceLocationMode service_location_mode = 12;
+  // True when the location has at least one posture policy assigned.
+  // Derived at query time; not stored as a column.
+  optional bool posture_check_required = 13;
 }
 
 enum ClientTrafficPolicy {
@@ -185,6 +188,8 @@ message ClientMfaStartRequest {
   int64 location_id = 1;
   string pubkey = 2;
   MfaMethod method = 3;
+  // Required when the location has posture policies assigned.
+  optional DevicePostureData posture_data = 4;
 }
 
 message ClientMfaStartResponse {
@@ -232,8 +237,69 @@ message CodeMfaSetupFinishResponse {
   repeated string recovery_codes = 1;
 }
 
-// OIDC authentication flow
+// Device posture types
+enum UnavailableReason {
+  UNAVAILABLE_REASON_UNSPECIFIED              = 0;
+  UNAVAILABLE_REASON_INSUFFICIENT_PERMISSIONS = 1;
+  UNAVAILABLE_REASON_NOT_APPLICABLE           = 2;
+  UNAVAILABLE_REASON_DETECTION_FAILED         = 3;
+}
 
+// Wrapper for a boolean posture signal that may be unavailable.
+message BoolCheck {
+  oneof result {
+    bool              value       = 1;
+    UnavailableReason unavailable = 2;
+  }
+}
+
+// Wrapper for a string posture signal that may be unavailable.
+message StringCheck {
+  oneof result {
+    string            value       = 1;
+    UnavailableReason unavailable = 2;
+  }
+}
+
+// Raw posture signals gathered by the client.
+message DevicePostureData {
+  // Full semver string including any pre-release suffix, e.g. "1.6.0-beta1"
+  string      defguard_client_version         = 1;
+  // Normalized OS family, e.g. "windows", "macos", "linux", "ios", "android"
+  StringCheck os_family                       = 2;
+  // Detailed OS name, e.g. "Windows", "Mac OS X", "Ubuntu"
+  StringCheck os_type                         = 3;
+  // OS version string, e.g. "11", "14.5", "22.04"
+  StringCheck os_version                      = 4;
+  BoolCheck   disk_encryption                 = 5;
+  BoolCheck   antivirus_present               = 6;
+  // ISO-8601 date; NotApplicable on Linux, iOS, and Android
+  StringCheck os_last_update_date             = 7;
+  // NotApplicable on non-Windows platforms
+  BoolCheck   ad_domain_joined                = 8;
+  // NotApplicable on non-Windows platforms
+  BoolCheck   windows_security_update_current = 9;
+  // NotApplicable on non-Linux platforms
+  StringCheck kernel_version                  = 10;
+  // NotApplicable on non-Android platforms
+  BoolCheck   android_device_integrity        = 11;
+}
+
+message DevicePostureCheckRequest {
+  int64             location_id  = 1;
+  string            pubkey       = 2;
+  DevicePostureData device_posture_data = 3;
+}
+
+message DevicePostureCheckResponse {
+  string preshared_key = 1;
+}
+
+message DevicePostureRejection {
+  repeated string failed_posture_checks = 1;
+}
+
+// External OIDC authentication flow
 enum AuthFlowType {
   AUTH_FLOW_TYPE_UNSPECIFIED = 0;
   AUTH_FLOW_TYPE_ENROLLMENT = 1;

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -272,14 +272,13 @@ message DevicePostureData {
   StringCheck os_version = 4;
   BoolCheck disk_encryption = 5;
   BoolCheck antivirus_present = 6;
-  StringCheck os_last_update_date = 7;
   // Windows only
-  BoolCheck windows_ad_domain_joined = 8;
-  BoolCheck windows_security_update_current = 9;
+  BoolCheck windows_ad_domain_joined = 7;
+  BoolCheck windows_security_update_current = 8;
   // Linux only
-  StringCheck linux_kernel_version = 10;
-  // Android only
-  BoolCheck android_device_integrity = 11;
+  StringCheck linux_kernel_version = 9;
+  // Android & macOS only
+  BoolCheck device_integrity = 10;
 }
 
 message DevicePostureCheckRequest {

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -120,8 +120,6 @@ message DeviceConfig {
   int32 keepalive_interval = 10;
   optional LocationMfaMode location_mfa_mode = 11;
   optional ServiceLocationMode service_location_mode = 12;
-  // True when the location has at least one posture policy assigned.
-  // Derived at query time; not stored as a column.
   optional bool posture_check_required = 13;
 }
 
@@ -239,16 +237,16 @@ message CodeMfaSetupFinishResponse {
 
 // Device posture types
 enum UnavailableReason {
-  UNAVAILABLE_REASON_UNSPECIFIED              = 0;
+  UNAVAILABLE_REASON_UNSPECIFIED = 0;
   UNAVAILABLE_REASON_INSUFFICIENT_PERMISSIONS = 1;
-  UNAVAILABLE_REASON_NOT_APPLICABLE           = 2;
-  UNAVAILABLE_REASON_DETECTION_FAILED         = 3;
+  UNAVAILABLE_REASON_NOT_APPLICABLE = 2;
+  UNAVAILABLE_REASON_DETECTION_FAILED = 3;
 }
 
 // Wrapper for a boolean posture signal that may be unavailable.
 message BoolCheck {
   oneof result {
-    bool              value       = 1;
+    bool value = 1;
     UnavailableReason unavailable = 2;
   }
 }
@@ -256,7 +254,7 @@ message BoolCheck {
 // Wrapper for a string posture signal that may be unavailable.
 message StringCheck {
   oneof result {
-    string            value       = 1;
+    string value = 1;
     UnavailableReason unavailable = 2;
   }
 }
@@ -264,30 +262,30 @@ message StringCheck {
 // Raw posture signals gathered by the client.
 message DevicePostureData {
   // Full semver string including any pre-release suffix, e.g. "1.6.0-beta1"
-  string      defguard_client_version         = 1;
+  string defguard_client_version = 1;
   // Normalized OS family, e.g. "windows", "macos", "linux", "ios", "android"
-  StringCheck os_family                       = 2;
+  StringCheck os_family = 2;
   // Detailed OS name, e.g. "Windows", "Mac OS X", "Ubuntu"
-  StringCheck os_type                         = 3;
+  StringCheck os_type = 3;
   // OS version string, e.g. "11", "14.5", "22.04"
-  StringCheck os_version                      = 4;
-  BoolCheck   disk_encryption                 = 5;
-  BoolCheck   antivirus_present               = 6;
+  StringCheck os_version = 4;
+  BoolCheck disk_encryption = 5;
+  BoolCheck antivirus_present = 6;
   // ISO-8601 date; NotApplicable on Linux, iOS, and Android
-  StringCheck os_last_update_date             = 7;
+  StringCheck os_last_update_date = 7;
   // NotApplicable on non-Windows platforms
-  BoolCheck   ad_domain_joined                = 8;
+  BoolCheck ad_domain_joined = 8;
   // NotApplicable on non-Windows platforms
-  BoolCheck   windows_security_update_current = 9;
+  BoolCheck windows_security_update_current = 9;
   // NotApplicable on non-Linux platforms
-  StringCheck kernel_version                  = 10;
+  StringCheck kernel_version = 10;
   // NotApplicable on non-Android platforms
-  BoolCheck   android_device_integrity        = 11;
+  BoolCheck android_device_integrity = 11;
 }
 
 message DevicePostureCheckRequest {
-  int64             location_id  = 1;
-  string            pubkey       = 2;
+  int64 location_id = 1;
+  string pubkey = 2;
   DevicePostureData device_posture_data = 3;
 }
 

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -274,10 +274,10 @@ message DevicePostureData {
   BoolCheck antivirus_present = 6;
   StringCheck os_last_update_date = 7;
   // Windows only
-  BoolCheck ad_domain_joined = 8;
+  BoolCheck windows_ad_domain_joined = 8;
   BoolCheck windows_security_update_current = 9;
   // Linux only
-  StringCheck kernel_version = 10;
+  StringCheck linux_kernel_version = 10;
   // Android only
   BoolCheck android_device_integrity = 11;
 }

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -272,15 +272,13 @@ message DevicePostureData {
   StringCheck os_version = 4;
   BoolCheck disk_encryption = 5;
   BoolCheck antivirus_present = 6;
-  // ISO-8601 date; NotApplicable on Linux, iOS, and Android
   StringCheck os_last_update_date = 7;
-  // NotApplicable on non-Windows platforms
+  // Windows only
   BoolCheck ad_domain_joined = 8;
-  // NotApplicable on non-Windows platforms
   BoolCheck windows_security_update_current = 9;
-  // NotApplicable on non-Linux platforms
+  // Linux only
   StringCheck kernel_version = 10;
-  // NotApplicable on non-Android platforms
+  // Android only
   BoolCheck android_device_integrity = 11;
 }
 

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -120,6 +120,7 @@ message DeviceConfig {
   int32 keepalive_interval = 10;
   optional LocationMfaMode location_mfa_mode = 11;
   optional ServiceLocationMode service_location_mode = 12;
+  // added for 2.1
   optional bool posture_check_required = 13;
 }
 
@@ -186,7 +187,7 @@ message ClientMfaStartRequest {
   int64 location_id = 1;
   string pubkey = 2;
   MfaMethod method = 3;
-  // Required when the location has posture policies assigned.
+  // [2.1] Required when the location has posture policies assigned.
   optional DevicePostureData posture_data = 4;
 }
 

--- a/common/client_types.proto
+++ b/common/client_types.proto
@@ -1,6 +1,8 @@
 syntax = "proto3";
 package defguard.client_types;
 
+import "enterprise/v2/posture/posture.proto";
+
 /*
  * Shared message and enum definitions used by Defguard desktop clients (desktop app and CLI).
  *
@@ -188,7 +190,7 @@ message ClientMfaStartRequest {
   string pubkey = 2;
   MfaMethod method = 3;
   // [2.1] Required when the location has posture policies assigned.
-  optional DevicePostureData posture_data = 4;
+  optional defguard.enterprise.posture.v2.DevicePostureData posture_data = 4;
 }
 
 message ClientMfaStartResponse {
@@ -234,65 +236,6 @@ message CodeMfaSetupFinishRequest {
 
 message CodeMfaSetupFinishResponse {
   repeated string recovery_codes = 1;
-}
-
-// Device posture types
-enum UnavailableReason {
-  UNAVAILABLE_REASON_UNSPECIFIED = 0;
-  UNAVAILABLE_REASON_INSUFFICIENT_PERMISSIONS = 1;
-  UNAVAILABLE_REASON_NOT_APPLICABLE = 2;
-  UNAVAILABLE_REASON_DETECTION_FAILED = 3;
-}
-
-// Wrapper for a boolean posture signal that may be unavailable.
-message BoolCheck {
-  oneof result {
-    bool value = 1;
-    UnavailableReason unavailable = 2;
-  }
-}
-
-// Wrapper for a string posture signal that may be unavailable.
-message StringCheck {
-  oneof result {
-    string value = 1;
-    UnavailableReason unavailable = 2;
-  }
-}
-
-// Raw posture signals gathered by the client.
-message DevicePostureData {
-  // Full semver string including any pre-release suffix, e.g. "1.6.0-beta1"
-  string defguard_client_version = 1;
-  // Normalized OS family, e.g. "windows", "macos", "linux", "ios", "android"
-  StringCheck os_family = 2;
-  // Detailed OS name, e.g. "Windows", "Mac OS X", "Ubuntu"
-  StringCheck os_type = 3;
-  // OS version string, e.g. "11", "14.5", "22.04"
-  StringCheck os_version = 4;
-  BoolCheck disk_encryption = 5;
-  BoolCheck antivirus_present = 6;
-  // Windows only
-  BoolCheck windows_ad_domain_joined = 7;
-  BoolCheck windows_security_update_current = 8;
-  // Linux only
-  StringCheck linux_kernel_version = 9;
-  // Android & macOS only
-  BoolCheck device_integrity = 10;
-}
-
-message DevicePostureCheckRequest {
-  int64 location_id = 1;
-  string pubkey = 2;
-  DevicePostureData device_posture_data = 3;
-}
-
-message DevicePostureCheckResponse {
-  string preshared_key = 1;
-}
-
-message DevicePostureRejection {
-  repeated string failed_posture_checks = 1;
 }
 
 // External OIDC authentication flow

--- a/enterprise/v2/posture/posture.proto
+++ b/enterprise/v2/posture/posture.proto
@@ -1,0 +1,60 @@
+syntax = "proto3";
+package defguard.enterprise.posture.v2;
+
+enum UnavailableReason {
+  UNAVAILABLE_REASON_UNSPECIFIED = 0;
+  UNAVAILABLE_REASON_INSUFFICIENT_PERMISSIONS = 1;
+  UNAVAILABLE_REASON_NOT_APPLICABLE = 2;
+  UNAVAILABLE_REASON_DETECTION_FAILED = 3;
+}
+
+// Wrapper for a boolean posture signal that may be unavailable.
+message BoolCheck {
+  oneof result {
+    bool value = 1;
+    UnavailableReason unavailable = 2;
+  }
+}
+
+// Wrapper for a string posture signal that may be unavailable.
+message StringCheck {
+  oneof result {
+    string value = 1;
+    UnavailableReason unavailable = 2;
+  }
+}
+
+// Raw posture signals gathered by the client.
+message DevicePostureData {
+  // Full semver string including any pre-release suffix, e.g. "1.6.0-beta1".
+  string defguard_client_version = 1;
+  // Normalized OS family, e.g. "windows", "macos", "linux", "ios", "android".
+  StringCheck os_family = 2;
+  // Detailed OS name, e.g. "Windows", "Mac OS X", "Ubuntu".
+  StringCheck os_type = 3;
+  // OS version string, e.g. "11", "14.5", "22.04".
+  StringCheck os_version = 4;
+  BoolCheck disk_encryption = 5;
+  BoolCheck antivirus_present = 6;
+  // Windows only
+  BoolCheck windows_ad_domain_joined = 8;
+  BoolCheck windows_security_update_current = 9;
+  // Linux only
+  StringCheck linux_kernel_version = 10;
+  // Android and macOS only
+  BoolCheck device_integrity = 11;
+}
+
+message DevicePostureCheckRequest {
+  int64 location_id = 1;
+  string pubkey = 2;
+  DevicePostureData device_posture_data = 3;
+}
+
+message DevicePostureCheckResponse {
+  string preshared_key = 1;
+}
+
+message DevicePostureRejection {
+  repeated string failed_posture_checks = 1;
+}

--- a/enterprise/v2/posture/posture.proto
+++ b/enterprise/v2/posture/posture.proto
@@ -28,10 +28,10 @@ message StringCheck {
 message DevicePostureData {
   // Full semver string including any pre-release suffix, e.g. "1.6.0-beta1".
   string defguard_client_version = 1;
-  // Normalized OS family, e.g. "windows", "macos", "linux", "ios", "android".
-  StringCheck os_family = 2;
-  // Detailed OS name, e.g. "Windows", "Mac OS X", "Ubuntu".
-  StringCheck os_type = 3;
+  // Normalized OS type, e.g. "Windows", "macOS", "Linux", "iOS", "Android".
+  string os_type = 2;
+  // Detailed OS name, e.g. "Windows", "Darwin", "Ubuntu".
+  StringCheck os_name = 3;
   // OS version string, e.g. "11", "14.5", "22.04".
   StringCheck os_version = 4;
   BoolCheck disk_encryption = 5;

--- a/v2/proxy.proto
+++ b/v2/proxy.proto
@@ -109,6 +109,8 @@ message CoreResponse {
     AwaitRemoteMfaFinishResponse await_remote_mfa_finish = 16;
     HttpsCerts https_certs = 17;
     google.protobuf.Empty clear_https_certs = 18;
+    defguard.client_types.DevicePostureCheckResponse device_posture_check    = 19;
+    defguard.client_types.DevicePostureRejection     device_posture_rejected = 20;
   }
 }
 
@@ -199,6 +201,7 @@ message CoreRequest {
     defguard.client_types.CodeMfaSetupFinishRequest code_mfa_setup_finish = 19;
     AwaitRemoteMfaFinishRequest await_remote_mfa_finish = 20;
     AcmeCertificate acme_certificate = 21;
+    defguard.client_types.DevicePostureCheckRequest device_posture_check = 22;
   }
 }
 

--- a/v2/proxy.proto
+++ b/v2/proxy.proto
@@ -109,8 +109,8 @@ message CoreResponse {
     AwaitRemoteMfaFinishResponse await_remote_mfa_finish = 16;
     HttpsCerts https_certs = 17;
     google.protobuf.Empty clear_https_certs = 18;
-    defguard.client_types.DevicePostureCheckResponse device_posture_check    = 19;
-    defguard.client_types.DevicePostureRejection     device_posture_rejected = 20;
+    defguard.client_types.DevicePostureCheckResponse device_posture_check = 19;
+    defguard.client_types.DevicePostureRejection device_posture_rejected = 20;
   }
 }
 

--- a/v2/proxy.proto
+++ b/v2/proxy.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 package defguard.proxy.v2;
 
 import "common/client_types.proto";
+import "enterprise/v2/posture/posture.proto";
 import "google/protobuf/empty.proto";
 import "v2/common.proto";
 
@@ -109,8 +110,8 @@ message CoreResponse {
     AwaitRemoteMfaFinishResponse await_remote_mfa_finish = 16;
     HttpsCerts https_certs = 17;
     google.protobuf.Empty clear_https_certs = 18;
-    defguard.client_types.DevicePostureCheckResponse device_posture_check = 19;
-    defguard.client_types.DevicePostureRejection device_posture_rejected = 20;
+    defguard.enterprise.posture.v2.DevicePostureCheckResponse device_posture_check = 19;
+    defguard.enterprise.posture.v2.DevicePostureRejection device_posture_rejected = 20;
   }
 }
 
@@ -201,7 +202,7 @@ message CoreRequest {
     defguard.client_types.CodeMfaSetupFinishRequest code_mfa_setup_finish = 19;
     AwaitRemoteMfaFinishRequest await_remote_mfa_finish = 20;
     AcmeCertificate acme_certificate = 21;
-    defguard.client_types.DevicePostureCheckRequest device_posture_check = 22;
+    defguard.enterprise.posture.v2.DevicePostureCheckRequest device_posture_check = 22;
   }
 }
 


### PR DESCRIPTION
Adds types related to reporting device posture checks and device flows involving posture checks.

Closes https://github.com/DefGuard/defguard/issues/2882